### PR TITLE
Midi release pitch skip fix

### DIFF
--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -545,7 +545,7 @@ s16 midi_chan_pitchbend[16];
 u8 midi_next_finger;
 u8 midi_lsb[32];
 u8 find_midi_note(u8 chan, u8 note) {
-	for (int fi = 0; fi < 8; ++fi) if (midi_notes[fi] == note && midi_channels[fi] == chan)
+	for (int fi = 0; fi < 8; ++fi) if ((midi_pitch_override & (1 << fi)) && midi_notes[fi] == note && midi_channels[fi] == chan)
 		return fi;
 	return 255;
 }


### PR DESCRIPTION
### Issue
Notes sent by midi would change pitch after being released, which resulted in an undesired pitch during the release stage of the envelope and possible undesired glide pitches. Plinky also generated an extra midi note at this undesired pitch. This issue only started after a midi start command was sent.

### Underlying issue
On receiving a note off command, the midi channel for that voice was cleared to indicate the note being turned off. But that (now non-existing) midi channel was still used for retrieving the desired pitch during the release stage, leading to undesired pitches. (Which in turn generated an extra midi output note at this undesired pitch.)

It is unclear why this problem only started after a midi start command was sent. It is also unclear whether the issue was the start command itself, or the sequencer starting as a result of it. (A similar bug, unrelated to midi but related to the sequencer starting, still exists.)

### Solution
The midi channel is no longer cleared at all.

Previously, the midi channel being cleared was an indication for this note no longer playing. To account for this, `find_midi_note()` now checks whether `midi_pitch_override` is set for this voice, which makes `midi_pitch_override` the new indicator for whether a note is playing or not.

In `DoAudio()` a check is added which checks whether `midi_pressure_override` is false (note is released) and the volume is very low (end of envelope release stage.) If so, `midi_pitch_override` for this voice is cleared, fully turning off the voice.

This solution also enables polyphonic aftertouch during the release stage.
