### PR TITLE
Read pattern fix

### DIFF
--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -522,8 +522,13 @@ bool read_from_seq = false;
 
 FingerRecord* readpattern(int fi) {
 	if (rampattern_idx == cur_pattern && shift_down != SB_CLEAR) {
-		return &rampattern[(cur_step >> 4) & 3].steps[cur_step & 15][fi];
-	} // pattern is ok?
+		FingerRecord* fr = &rampattern[(cur_step >> 4) & 3].steps[cur_step & 15][fi];
+        // is the first frame empty?
+        if (fr->pressure[0] == 0) {
+            return 0; // not a valid pattern step
+        }
+		return fr;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
`readPattern()` didn't check whether a sequencer step was actually empty, which led to plinky sometimes sounding out steps that were empty. (Any valid pointer was considered a valid sequencer step.)  Added a check which checks for the presence of any pressure in the first frame of the step before returning the pointer.

This specifically resolves releasing a note while the sequencer is playing having a pitch-skip during the release phase.