### PR TITLE
Auto revert to internal clock

### DIFF
--- a/sw/Core/Src/arp.h
+++ b/sw/Core/Src/arp.h
@@ -501,7 +501,12 @@ int update_clock(void) { // returns 1 for clock, 2 for half clock, 0 for neither
 //	clk_in_high_prev = clk_in_high;
 //	reset_in_high_prev = reset_in_high;
 #define ACCURATE_FS 31250
-	//////////////////////////////////////////// intenral clock
+
+	// revert to internal clock after not getting any external clock signal for a second
+	if (external_clock_enable && ticks_since_clock >= 500) // a tick is 2ms
+		external_clock_enable = false;
+
+	//////////////////////////////////////////// internal clock
 	if (!external_clock_enable) {
 		bpm10x = ((param_eval_int(P_TEMPO, any_rnd, env16, pressure16) * 1200) >> 16) + 1200;
 

--- a/sw/Core/Src/edit.h
+++ b/sw/Core/Src/edit.h
@@ -410,7 +410,6 @@ void finger_editing(int fi, int frame) {
 							firsttaptime = ticks();
 						tapcount++;
 
-						external_clock_enable = false;
 						if (tapcount > 1) { // tap tempo!
 							float taps_per_minute = (32000.f * (tapcount - 1) * 60.f) / ((ticks() - firsttaptime) * BLOCK_SAMPLES);
 							//DebugLog("%d - %0.1f\n", tapcount, taps_per_minute);


### PR DESCRIPTION
### Issue
Sequencer functionality breaks after having been sequenced from an external midi device

### Underlying issue
Plinky automatically switches to external clock when it receives one, but only changes back to internal clock when the bpm is manually  set on the device. If the external clock disappears, the sequencer functionality breaks. Some midi-sequencers stop sending clock when they are not playing, leading to this issue on Plinky

### Solution
When Plinky doesn't receive any external clock for one second, it automatically switches back to internal clock and the preset bpm. Removed changing to internal clock when the bpm is changed manually, as that no longer does anything.