### PR TITLE
Clear latch on preset load

### DIFF
--- a/sw/Core/Src/params.h
+++ b/sw/Core/Src/params.h
@@ -787,6 +787,7 @@ void SetPreset(u8 preset, bool force) {
 	if (preset == sysparams.curpreset && !force)
 		return;
 	sysparams.curpreset = preset;
+	clearlatch();
 	CopyPresetToRam(force);
 	ramtime[GEN_SYS]=millis();
 }


### PR DESCRIPTION
As it says on the tin
Prevents unpleasantly loud surprises when loading a new sound - users purposely wanting to keep a sound droning after switching presets seems unlikely

(Trying to take some small changes out of #28)