### PR TITLE
Maintain midi pitch through release

### DIFF
--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -1565,7 +1565,6 @@ void processmidimsg(u8 msg, u8 d1, u8 d2) {
 		u8 fi = find_midi_note(chan, d1);
 		if (fi < 8) {
 			midi_pressure_override &= ~(1 << fi);
-			midi_channels[fi] = 255;
 		}
 	}
 	break;
@@ -2021,6 +2020,11 @@ void DoAudio(u32 *dst, u32 *audioin) {
 					voices[fi].theosc[i].pitch = pitch;
 					voices[fi].theosc[i].targetdphase = maxi(65536, (int)(table_interp(pitches, pitch + PITCH_BASE) * (65536.f * 128.f)));
 					++f;
+				}
+				// midi note is released and volume has rung out
+				if (!(midi_pressure_override & (1 << fi)) && (voices[fi].vol < 0.001f)) {
+					// disable pitch override, this truly turns off the note
+					midi_pitch_override &= ~(1 << fi);
 				}
 			}
 			else {

--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -545,7 +545,7 @@ s16 midi_chan_pitchbend[16];
 u8 midi_next_finger;
 u8 midi_lsb[32];
 u8 find_midi_note(u8 chan, u8 note) {
-	for (int fi = 0; fi < 8; ++fi) if (midi_notes[fi] == note && midi_channels[fi] == chan)
+	for (int fi = 0; fi < 8; ++fi) if ((midi_pitch_override & (1 << fi)) && midi_notes[fi] == note && midi_channels[fi] == chan)
 		return fi;
 	return 255;
 }


### PR DESCRIPTION
This makes it so that `find_midi_note()` considers a midi note active as long as `midi_pitch_override` is set, while it used to check  whether `midi_channels[fi]` was cleared.

This allows `midi_channels[fi]` to stay valid during the release time of a midi note, as it is used to read out its pitch

The volume of the voice gets checked to properly clear `midi_pitch_override` when the voice has rung out

This also enables polyphonic aftertouch during the release phase of midi notes