### PR TITLE
Simplify find midi free channel

### DIFF
--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -550,24 +550,32 @@ u8 find_midi_note(u8 chan, u8 note) {
 	return 255;
 }
 u8 find_midi_free_channel(void) {
-	u8 numfingerdown = 0;
-	
-	for (int attempt = 0; attempt < 16; ++attempt) {
-		u8 ch = (midi_next_finger++) & 7;
-		bool fingerdown = touch_synth_getlatest(ch)->pressure > 0 && (midi_pressure_override&(1<<ch))==0; // synth_dst_finger>0, and midi_pressure_override bit is not set
-		if (fingerdown) {
-			if (attempt < 8) {
-				numfingerdown++;
-				if (numfingerdown == 8)
-					return 255; // all fingers using channels! NO ROOM! TOUGH
-			}
-			continue;
-		}
-		if (attempt >=8 || midi_channels[ch] == 255)
-			return ch;
-	}
-	// give up
-	return (midi_next_finger++) & 7;
+	// "dumb" implementation: just find the lowest unused string
+	for (u8 i = 0; i < 8; i++)
+		if (!(synthfingerdown_nogatelen_internal & (1 << i)))
+			return i;
+	// no unused string found
+	return 255;
+
+	// RJ: I'm really not quite sure what this code was doing exactly. Keeping it here for reference
+	//
+	// u8 numfingerdown = 0;
+	// for (int attempt = 0; attempt < 16; ++attempt) {
+	// 	u8 ch = (midi_next_finger++) & 7;
+	// 	bool fingerdown = touch_synth_getlatest(ch)->pressure > 0 && (midi_pressure_override&(1<<ch))==0; // synth_dst_finger>0, and midi_pressure_override bit is not set
+	// 	if (fingerdown) {
+	// 		if (attempt < 8) {
+	// 			numfingerdown++;
+	// 			if (numfingerdown == 8)
+	// 				return 255; // all fingers using channels! NO ROOM! TOUGH
+	// 		}
+	// 		continue;
+	// 	}
+	// 	if (attempt >=8 || midi_channels[ch] == 255)
+	// 		return ch;
+	// }
+	// // give up
+	// return (midi_next_finger++) & 7;
 }
 
 bool is_finger_an_edit_operation(int fi);


### PR DESCRIPTION
This code was technically working, but I could not work out how or what the intention behind it was
For legibility and robustness, this is rewritten in a very simple way
If we want to update it at a later point re: voice allocation, this is a good jumping-off point