### PR TITLE
Midi improvements, voice allocation reorder, ghost note fix

### DIFF
--- a/sw/Core/Src/params.h
+++ b/sw/Core/Src/params.h
@@ -401,16 +401,20 @@ const static u16 scaletab[S_LAST][16] = {
 
 
 
-
+// returns number of notes in scale
 static inline u8 scalelen(int scale) {
 	return scaletab[scale][0];
 }
+
+// returns pitch, step is relative to C1
 static inline int lookupscale(int scale, int step) {
-	u8 len=scaletab[scale][0];
-	int oct=step/len;
-	step-=oct*len;
-	if (step<0) { step+=len; oct--; }
-	return oct*(12*512) + scaletab[scale][step+1];
+	int oct = step / scalelen(scale);
+	step -= oct * scalelen(scale);
+	if (step < 0) {
+		step += scalelen(scale); 
+		oct--; 
+	}
+	return oct * (12 * 512) + scaletab[scale][step+1];
 }
 
 

--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -2050,11 +2050,10 @@ void DoAudio(u32 *dst, u32 *audioin) {
 				int microtune = 64 + param_eval_finger(P_MICROTUNE, fi, synthf);  // really, micro-tune amount
 
 				Finger* f = fingers_synth_sorted[fi] + 2;
+				int position = f->pressure <= 0 ? memory_position[fi] : f->pos;
+				int ystep = 7 - (position >> 8);
+				int fine = 128 - (position & 255);
 				for (int i = 0; i < 4; ++i) {
-					//				if (ramsample.samplelen)
-					//					f = synthf; // XXX FORCE LATEST
-					int ystep = 7 - (f->pos >> 8);
-					int fine = 128 - (f->pos & 255);
 					int pitch = pitchbase + (lookupscale(scale, ystep + root)) + ((i & 1) ? interval : 0) + ((fine * microtune) >> 14);
 					totpitch += pitch;
 					voices[fi].theosc[i].pitch = pitch;

--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -1571,7 +1571,7 @@ void processmidimsg(u8 msg, u8 d1, u8 d2) {
 	case 9: { // note down
 		u8 fi = find_midi_note(chan, d1);
 		if (fi == 255)
-			fi = find_midi_free_channel();
+			fi = find_free_midi_string(d1);
 		if (fi < 8) {
 			midi_notes[fi] = d1;
 			midi_channels[fi] = chan;

--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -2018,7 +2018,7 @@ void DoAudio(u32 *dst, u32 *audioin) {
 			int interval = (param_eval_finger(P_INTERVAL, fi, synthf) * 12) >> 7;
 			int totpitch = 0;
 			// sounding out a midi note
-			if (midi_pitch_override & bit) {
+			if ((midi_pitch_override & bit) && !(midi_suppress & bit)) {
 				Finger* f = fingers_synth_sorted[fi] + 2;
 				int midinote = ((midi_notes[fi]-12*2) << 9) + midi_chan_pitchbend[midi_channels[fi]]/8;
 				for (int i = 0; i < 4; ++i) {

--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -1560,18 +1560,24 @@ void processmidimsg(u8 msg, u8 d1, u8 d2) {
 		if (d1<32)
 			SetPreset(d1, false);
 		break;
-	case 8: { // note up 
-	   // find the voice for this note up
+	case 8: { // note off 
+		// find string with existing midi note
 		u8 fi = find_midi_note(chan, d1);
 		if (fi < 8) {
 			midi_pressure_override &= ~(1 << fi);
 		}
 	}
 	break;
-	case 9: { // note down
+	case 9: { // note on
+		int note_position;
+		// find string with existing midi note
 		u8 fi = find_midi_note(chan, d1);
-		if (fi == 255)
-			fi = find_free_midi_string(d1);
+		// none found - find empty string
+		if (fi == 255) {
+			fi = find_free_midi_string(d1, &note_position);
+			midi_positions[fi] = note_position;
+		}
+		// set midi values
 		if (fi < 8) {
 			midi_notes[fi] = d1;
 			midi_channels[fi] = chan;

--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -1999,6 +1999,7 @@ void DoAudio(u32 *dst, u32 *audioin) {
 		cvpitch = (cvpitch + 256) & (~511);
 	}
 	for (int fi = 0; fi < 8; ++fi) {
+		u8 bit = 1 << fi;
 		Finger* synthf = touch_synth_getlatest(fi);
 		float vol = (synthf->pressure) * 1.f / 2048.f ; // sensitivity
 		{
@@ -2016,7 +2017,8 @@ void DoAudio(u32 *dst, u32 *audioin) {
 			int root = param_eval_finger(P_ROTATE, fi, synthf);
 			int interval = (param_eval_finger(P_INTERVAL, fi, synthf) * 12) >> 7;
 			int totpitch = 0;
-			if (midi_pitch_override & (1 << fi)) {
+			// sounding out a midi note
+			if (midi_pitch_override & bit) {
 				Finger* f = fingers_synth_sorted[fi] + 2;
 				int midinote = ((midi_notes[fi]-12*2) << 9) + midi_chan_pitchbend[midi_channels[fi]]/8;
 				for (int i = 0; i < 4; ++i) {
@@ -2027,11 +2029,12 @@ void DoAudio(u32 *dst, u32 *audioin) {
 					++f;
 				}
 				// midi note is released and volume has rung out
-				if (!(midi_pressure_override & (1 << fi)) && (voices[fi].vol < 0.001f)) {
+				if (!(midi_pressure_override & bit) && (voices[fi].vol < 0.001f)) {
 					// disable pitch override, this truly turns off the note
-					midi_pitch_override &= ~(1 << fi);
+					midi_pitch_override &= ~bit;
 				}
 			}
+			// anything but a midi note
 			else {
 				u32 scale = param_eval_finger(P_SCALE, fi, synthf);
 				if (scale >= S_LAST) scale = 0;

--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -707,6 +707,7 @@ void finger_synth_update(int fi) {
 	static u8 last_edited_substep_global = 255;
 	static u8 last_edited_step[8] = {255, 255, 255, 255, 255, 255, 255, 255};
 	static int record_to_substep;
+	static bool suppress_latch = false;
 
 	int bit = 1 << fi;
 	int ui_frame = (finger_frame_ui - (finger_ui_done_this_frame & bit ? 0 : 1)) & 7;
@@ -747,11 +748,15 @@ void finger_synth_update(int fi) {
 						latch[i].minpos = 0;
 						latch[i].maxpos = 0;
 					}
+					// in step record mode, trying to start a new latch temporarily turns off latching
+					// trying to start a new latch outside of step record mode turns it on again
+					suppress_latch = recording && !isplaying();
 				}
 				// save latch values
-				latch[fi].avgvel = pres_compress(pressure);
-				latch[fi].minpos = pos_compress(position);
-
+				if (!suppress_latch) {
+					latch[fi].avgvel = pres_compress(pressure);
+					latch[fi].minpos = pos_compress(position);
+				}
 				// RJ: I could not work out a way to work with average values that wasn't
 				// sluggish or gave undesired intermediate values - slides and in-between notes
 				// Current solution is just saving one value and randomizing when reading it out

--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -699,10 +699,6 @@ int pos_decompress(int position) {
 }
 
 void finger_synth_update(int fi) {
-	const static int max_midi_pressure = 1 << 12; // max midi velocity translates to this pressure value
-	const static u8 midi_velocity_multiplier = max_midi_pressure >> 7; 
-	const static float max_midi_pressure_multiplier = 1.5f; // midi pressure can multiply max_midi_pressure by max this value
- 
 	static u8 last_edited_step_global = 255;
 	static u8 last_edited_substep_global = 255;
 	static u8 last_edited_step[8] = {255, 255, 255, 255, 255, 255, 255, 255};
@@ -902,11 +898,7 @@ void finger_synth_update(int fi) {
 	// a midi note is playing this string
 	if ((midi_pressure_override & bit) && !(midi_suppress & bit)) {
 		// take pressure and position from midi data
-		pressure = 
-			// velocity scales from 0 to max_midi_pressure
-			midi_velocities[fi] * midi_velocity_multiplier * 
-			// midi pressure multiplier is 1 plus (max_midi_pressure_multiplier - 1) times the midi pressure in range [0..1]
-			(maxi(midi_aftertouch[fi], midi_chan_aftertouch[midi_channels[fi]]) / 127.0f * (max_midi_pressure_multiplier - 1) + 1);			
+		pressure = 1+(midi_velocities[fi] + maxi(midi_aftertouch[fi], midi_chan_aftertouch[midi_channels[fi]]))*16;		
 		// for midi, position only defines where the leds light up on the string        
 		position = midi_positions[fi];
 	}

--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -733,9 +733,10 @@ void finger_synth_update(int fi) {
 		}
 		else physical_touch_finger &= ~bit;
 
-		// === LATCH WRITE === // 
-
 		if (latchon) {
+
+			// === LATCH WRITE === // 
+
 			// finger touching and pressure increasing
 			if (pressure > 0 && pressure_increasing) {
 				// is this a new touch after no fingers where touching?
@@ -771,6 +772,25 @@ void finger_synth_update(int fi) {
 				// latch[fi].avgvel = maxpressure;
 				// latch[fi].minpos = minpos;
 				// latch[fi].maxpos = maxpos;
+			}
+
+			// === LATCH RECALL === // 
+
+			// latch pressure larger than touch pressure
+			if (latch[fi].avgvel > 0 && latch[fi].avgvel * 24 > pressure) {
+				//recall latch values
+				pressure = pres_decompress(latch[fi].avgvel);;
+				position = pos_decompress(latch[fi].minpos);
+				position_updated = true;
+
+				// Averaging code for reference:
+				//
+				// int minpos = latch[fi].minpos * 8 + 2;
+				// int maxpos = latch[fi].maxpos * 8 + 6;
+				// int avgpos = (minpos + maxpos) / 2;
+				// int range = (maxpos - minpos) / 4;
+				// pressure = latchpres ? randrange(latchpres - 12, latchpres) : -1024;
+				// position = randrange(avgpos-range,avgpos+range);
 			}
 		}
 
@@ -850,25 +870,6 @@ void finger_synth_update(int fi) {
 			// clear this for next recording
 			last_edited_step_global = 255;
 		}
-	}
-
-	// === LATCH RECALL === // 
-
-	// latch pressure larger than touch pressure
-	if (latch[fi].avgvel > 0 && latch[fi].avgvel * 24 > pressure) {
-		//recall latch values
-		pressure = pres_decompress(latch[fi].avgvel);;
-		position = pos_decompress(latch[fi].minpos);
-		position_updated = true;
-
-		// Averaging code for reference:
-		//
-		// int minpos = latch[fi].minpos * 8 + 2;
-		// int maxpos = latch[fi].maxpos * 8 + 6;
-		// int avgpos = (minpos + maxpos) / 2;
-		// int range = (maxpos - minpos) / 4;
-		// pressure = latchpres ? randrange(latchpres - 12, latchpres) : -1024;
-		// position = randrange(avgpos-range,avgpos+range);
 	}
 
 	// === SEQ PLAYING === //

--- a/sw/Core/Src/ui.h
+++ b/sw/Core/Src/ui.h
@@ -529,9 +529,8 @@ void DrawVoices(void) {
 	static float touchLineHeight[8];
 	static float maxVolume[8];
 	static float volLineHeight[8];
-	//static bool stringWasTouched[8];
     u8 rightOffset = (rampreset.flags & FLAGS_LATCH) ? 38 : 14;
-
+	// all voices
     for (u8 i = 0; i < 8; i++) {
 		// string volume
 		if (maxVolume[i] != 0) {
@@ -555,9 +554,6 @@ void DrawVoices(void) {
 				touchLineHeight[i] -= moveSpeed;
 			if (touchLineHeight[i] < 0 )
 				touchLineHeight[i] = 0;
-			// // released this frame
-			// if (stringWasTouched[i])
-
 			// has the sound died out?
 			if (maxVolume[i] != 0 && volLineHeight[i] < 0.25) {
 				// disable volume line
@@ -572,8 +568,6 @@ void DrawVoices(void) {
 				vline(x - barWidth / 2 + dx, H - 1 - touchLineHeight[i], H - 1, 2);
 		}
 		hline(x - barWidth / 2, H - 1 - volLineHeight[i], x - barWidth / 2 + barWidth, 1);
-		// remember string touches
-		//stringWasTouched[i] = synthfingerdown_nogatelen & (1 << i);
     }
 }
 


### PR DESCRIPTION
I decided to put these all in one PR. I did put everything in separate commits. If there's no bugs, this should constitute v0.B

## Changes
### Improve midi voice allocation
1. Incoming midi notes try to map themselves to a string they could also be played on by touch
  a. The average pitch of each string `(pad 0 pitch + pad 7 pitch) / 2` is collected and compared to the midi pitch. We try to map the midi note to the (non-sounding) string with the closest average pitch
  b. Even if the first desired string is not available, mapping to one string higher or lower still yields a fair chance that the midi note exists on this string
  c. If there is no non-sounding string available, we map to the (non-pressed) string with the lowest volume
2. Before returning the chosen string number, the position of the midi note on the string is defined
  a. Notes in the scale map to the exact pad on the string that represents the midi pitch
  b. Accidentals round down to the nearest note in scale
  c. Notes fully higher or lower than the chosen string map to pad 7 and 0 respectively
3. If there is no non-pressed string available, the midi note is ignored

_From this point, sequencing or latching midi notes does not seem far away_
### Reorder touch-source priority
Priority is now:
1. Touch
2. Sequencer
3. Midi

Higher priority notes will sound instead of lower priority notes when played on the same string at the same time. But when the higher priority note releases and the lower priority note is still pressed, the lower priority note will take over again.
### CV gate scaling
CV gate scaling of the pressure on a string is now applied at the very end of the note registration. Touch, sequencer and midi are all processed first, and whatever pressure is generated at the end gets scaled by the incoming cv gate signal
### Ghost note fix
Whenever touch, latch or sequencer generates a note, its touch position is stored in memory. When no touch is generated at all, `DoAudio()` always plays from the position stored in memory. This prevents pitches from skipping after a touch is released or cancelled.
### Latch during step record mode
- Being in latch mode could complicate step recording. For that reason, latch will now be temporarily suppressed when a new latch is started while in step record mode. This brings back the expected auto-step functionality in step record mode. After step record is turned off, latch resumes working as usual (fixes #39)
- If a latch is playing when step record mode is turned on, it will be recorded into the active step. The sequencer behavior in this scenario is a bit wonky. The alternative is stopping the latch immediately as soon as record is enabled, which could lead to undesired situations if record is pressed accidentally. I feel like the current solution is the least-bad one