### PR TITLE
Support for alternate display (SSD1305)

### DIFF
--- a/sw/Core/Src/config.h
+++ b/sw/Core/Src/config.h
@@ -62,6 +62,10 @@
 // 0.B0 - MORE RJ MAGIC - https://github.com/plinkysynth/plinky_public/pull/40 - what a beast he is.
 #define VERSION2			  "v0.B0"
 
+// 0.X0 - experimental build (SSD1305)
+//#define SSD1305
+//#define VERSION2			  "v0.X0"
+
 // the bootloader is manually copied to the file golden_bootloader.bin
 // makebin.py uses it to make a UF2 file containing the bootloader + latest firmware together
 // it also checksums the firmware and prints out the value. it should match this value

--- a/sw/Core/Src/oled.h
+++ b/sw/Core/Src/oled.h
@@ -79,6 +79,12 @@ void oled_flip(const u8* vram_with_offset) {
 	ssd1306_command(0); // Page start address (0 = reset)
 //	ssd1306_command(3); // Page end address - 32 pixels. 1=16 pixels
 
+#ifdef SSD1305
+	ssd1306_command(SSD1306_COLUMNADDR);
+	ssd1306_command(0 + 4);   // Column start address (0 = reset) // 0 + 4
+	ssd1306_command(W - 1 + 4); // Column end address (127 = reset) // W - 1 + 4
+#endif
+
 	HAL_StatusTypeDef r = 	HAL_I2C_Master_Transmit(&hi2c2, oled_i2caddr, (u8*)vram_with_offset, W * H / 8+1, 500);
 	if (r != HAL_OK)
 		DebugLog("error in ssd1306 data %d\r\n", (int) r);
@@ -108,8 +114,13 @@ void oled_init(void) {
 	ssd1306_command(0x00);                                  // 0x0 act like ks0108
 	ssd1306_command(SSD1306_SEGREMAP | 0x1);
 	ssd1306_command(SSD1306_COMSCANDEC);
+#ifdef SSD1305
+	ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA for 1305
+	ssd1306_command(0x12);                                  // 0x12
+#else
 	ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA
 	ssd1306_command(0x02);
+#endif	
 	ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
 	ssd1306_command(0x8F);
 
@@ -117,12 +128,16 @@ void oled_init(void) {
 	ssd1306_command(0xF1); // switchcap
 	ssd1306_command(SSD1306_SETVCOMDETECT);                 // 0xDB
 	ssd1306_command(0x40);
+#ifdef SSD1305
+	ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA for 1305
+	ssd1306_command(0x12);                                  // 0x12
+#endif
 	ssd1306_command(SSD1306_DISPLAYALLON_RESUME);           // 0xA4
 	ssd1306_command(SSD1306_NORMALDISPLAY);                 // 0xA6
 
 	ssd1306_command(SSD1306_DEACTIVATE_SCROLL);
 
-// put the plinky logo up before switching on the screen
+	// put the plinky logo up before switching on the screen
 	// prepare flip
 	ssd1306_command(SSD1306_COLUMNADDR);
 	ssd1306_command(0);   // Column start address (0 = reset)


### PR DESCRIPTION
Adds support for alternate display driver (SSD1305). The driver is very similar so very few line changes are needed, and they are confined to oled.h. Tested on hardware with a screen of the same resolution.

Using the alternate display is an opt-in via compiler flag in config.h:
#define SSD1305