### PR TITLE
Fix #34

### DIFF
--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -1915,6 +1915,7 @@ void DoAudio(u32 *dst, u32 *audioin) {
 	if (!whichhalf) {
 		total_ui_pressure = 0;
 		read_from_seq = false;
+		prev_physical_touch_finger = physical_touch_finger;
 	}
 	// update strings
 	for (int fi = whichhalf; fi < whichhalf + 4; ++fi) {
@@ -1923,7 +1924,7 @@ void DoAudio(u32 *dst, u32 *audioin) {
 	// end of a full update of all strings
 	if (whichhalf) {
 		// you've released your fingers, you're recording in step mode - let's advance!
-		if (total_ui_pressure<=0 && prev_total_ui_pressure <= 0 && prev_prev_total_ui_pressure > 0 && recording && !isplaying()) {
+		if (!physical_touch_finger && prev_physical_touch_finger && recording && !isplaying()) {
 			set_cur_step(cur_step + 1, false);
 		}
 		prev_prev_total_ui_pressure = prev_total_ui_pressure;

--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -515,6 +515,7 @@ static inline int randrange(int mn, int mx) {
 int param_eval_finger(u8 paramidx, int fingeridx, Finger* f);
 u8 synthfingerdown_nogatelen_internal;
 u8 physical_touch_finger = 0;
+u8 prev_physical_touch_finger = 0;
 bool read_from_seq = false;
 
 


### PR DESCRIPTION
When checking whether the sequencer should automatically step forward because it is in step-recording mode, it now only checks for physical touches. It used to check for any kind of pressure, including midi and latch