### PR TITLE
v0b1 fixes

### DIFF
--- a/sw/Core/Src/adc.h
+++ b/sw/Core/Src/adc.h
@@ -47,7 +47,7 @@ CVCalib cvcalib[10] = {
 	{42511.f, (26634-42511) * (1.f / (2048.f * 12.f * 2.f))},
 };
 
-static inline int GetADCSmoothedNoCalib(int chan) {
+static inline int GetADCNoCalib(int chan) {
 	u32 rv = 0;
 	u16* src = adcbuf + chan;
 	if (chan == ADC_GATE) { // get max not average, to respond to short gates better
@@ -64,8 +64,8 @@ static inline int GetADCSmoothedNoCalib(int chan) {
 	return rv / ADC_SAMPLES;
 }
 
-static inline float GetADCSmoothed(int chan) {
-	return (GetADCSmoothedNoCalib(chan) - cvcalib[chan].bias) * cvcalib[chan].scale;
+static inline float GetADCCalibrated(int chan) {
+	return (GetADCNoCalib(chan) - cvcalib[chan].bias) * cvcalib[chan].scale;
 }
 
 //volatile u32 adccounter;

--- a/sw/Core/Src/arp.h
+++ b/sw/Core/Src/arp.h
@@ -457,8 +457,7 @@ void OnGotReset(void) {
 
 extern volatile u8 gotclkin;
 volatile u8 gotclkin=0;
-
-
+volatile bool clkin_is_euro = false;
 
 int update_clock(void) { // returns 1 for clock, 2 for half clock, 0 for neither
 	tick++;
@@ -470,8 +469,16 @@ int update_clock(void) { // returns 1 for clock, 2 for half clock, 0 for neither
 	if(newgotclk!=prevgotclk) {
 		prevgotclk=newgotclk;
 		gotclock=true;
-		external_clock_enable=true;
+		// when we're switching from internal clock to external clock and that switch is triggered
+		// by a eurorack clock, the sequencer resets and starts playing
+		if ((!external_clock_enable) && clkin_is_euro) {
+			u8 loopstart_step = (rampreset.loopstart_step_no_offset + step_offset) & 63;
+			set_cur_step(loopstart_step, true);
+			playmode = PLAYING;
+		}
+		external_clock_enable = true;
 	}
+	clkin_is_euro = false;
 
 	/*
 	for (int i = 0; i < ADC_SAMPLES * ADC_CHANS; i += ADC_CHANS) {
@@ -503,8 +510,12 @@ int update_clock(void) { // returns 1 for clock, 2 for half clock, 0 for neither
 #define ACCURATE_FS 31250
 
 	// revert to internal clock after not getting any external clock signal for a second
-	if (external_clock_enable && ticks_since_clock >= 500) // a tick is 2ms
+	if (external_clock_enable && ticks_since_clock >= 500) { // a tick is 2ms
 		external_clock_enable = false;
+		// we probably don't want to keep playing the sequencer through a clock source change
+		if ((playmode == PLAYING) || (playmode == PLAY_WAITING_FOR_CLOCK_START) || (playmode == PLAY_WAITING_FOR_CLOCK_STOP))
+			playmode = PLAY_STOPPED;
+	}
 
 	//////////////////////////////////////////// internal clock
 	if (!external_clock_enable) {

--- a/sw/Core/Src/arp.h
+++ b/sw/Core/Src/arp.h
@@ -489,7 +489,7 @@ int update_clock(void) { // returns 1 for clock, 2 for half clock, 0 for neither
 	} else 	if (playmode == PLAYING && seqdiv < 0 && getgatesense()) {
 		// gate cv controls step
 		static bool curgate_digital = true;
-		float curgate = GetADCSmoothed(ADC_GATE);
+		float curgate = GetADCCalibrated(ADC_GATE);
 		float thresh = curgate_digital ? 0.01f : 0.02f;
 		bool newgate_digital = curgate > thresh;
 		if (newgate_digital && !curgate_digital) {

--- a/sw/Core/Src/main.c
+++ b/sw/Core/Src/main.c
@@ -166,8 +166,11 @@ void EncoderTick(void) {
 	lastencstate=newstate;
 }
 
+extern volatile bool clkin_is_euro;
+
 void ClockIRQ(void){
 	gotclkin++;
+  clkin_is_euro = true;
 }
 
 int16_t accel_raw[3];

--- a/sw/Core/Src/params.h
+++ b/sw/Core/Src/params.h
@@ -265,7 +265,7 @@ const static u8 param_flags[P_LAST] = {
 	[P_R]=0,
 
 
-	[P_OCT]=4+FLAG_SIGNED,
+	[P_OCT]=3+FLAG_SIGNED,
 	[P_PITCH]=FLAG_SIGNED,
 	[P_GLIDE]=0,
 	[P_INTERVAL]=FLAG_SIGNED,

--- a/sw/Core/Src/params.h
+++ b/sw/Core/Src/params.h
@@ -265,7 +265,7 @@ const static u8 param_flags[P_LAST] = {
 	[P_R]=0,
 
 
-	[P_OCT]=3+FLAG_SIGNED,
+	[P_OCT]=4+FLAG_SIGNED,
 	[P_PITCH]=FLAG_SIGNED,
 	[P_GLIDE]=0,
 	[P_INTERVAL]=FLAG_SIGNED,

--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -323,6 +323,7 @@ extern int16_t accel_raw[3];
 extern float accel_lpf[2];
 extern float accel_smooth[2];
 s16 accel_sens=0;
+u8 lfo_scope_frame;
 
 //extern int debuga[4];
 //int debuga[4];
@@ -448,14 +449,16 @@ void update_params(int fingertrig, int fingerdown) {
 	knobsmooth_update_knob(adc_smooth + 5, bknob, 1.f);
 	knobsmooth_update_cv(adc_smooth + 6, pitchcv);
 	knobsmooth_update_cv(adc_smooth + 7, gatecv);
-	u8 prevlfohp = (lfo_history_pos >> 4) & 15;
-	lfo_history_pos++;
-	u8 lfohp = (lfo_history_pos >> 4) & 15;
-	if (lfohp != prevlfohp)
-		lfo_history[lfohp][0] =
-		lfo_history[lfohp][1] =
-		lfo_history[lfohp][2] =
-		lfo_history[lfohp][3] = 0;
+
+	// every 16 frames, lfo_scope_frame increments and data for that frame is cleared
+	bool new_scope_frame = (ticks() & 15) == 0;
+	if (new_scope_frame) {
+		lfo_scope_frame = (ticks() >> 4) & 15;
+		lfo_history[lfo_scope_frame][0] =
+		lfo_history[lfo_scope_frame][1] =
+		lfo_history[lfo_scope_frame][2] =
+		lfo_history[lfo_scope_frame][3] = 0;
+	}
 	//compute new mod_cur for each mod source
 	int phase0 = calcseqsubstep(0, 65536);
 	int phase1 = phase0 + (65536 / 8);
@@ -473,6 +476,7 @@ void update_params(int fingertrig, int fingerdown) {
 	s8* autoknob1 = rampattern[q1].autoknob[(cur_step & 15) * 8 + (phase0>>13)];
 	s8* autoknob2 = rampattern[q2].autoknob[(nextstep & 15) * 8 + (phase1>>13)];
 	float autoknobinterp = (phase0 & (65536 / 8 - 1)) * (1.f/(65536/8));
+	static s8 prev_scopey[4] = {0};
 	for (int i = 0; i < 4; ++i) {
 		float adc = adc_smooth[i].y2;
 		float adcknob = 0.f;
@@ -516,12 +520,20 @@ void update_params(int fingertrig, int fingerdown) {
 		float expander_val = mod_cur[M_A + i] * (EXPANDER_GAIN * EXPANDER_RANGE / 65536.f);
 		expander_out[i] = clampi(EXPANDER_ZERO - (int)(expander_val), 0, EXPANDER_MAX);
 
-
+		// save lfo positions for oled scope
+		u8 old_scopey = prev_scopey[i];
 		u8 scopey = clampi((-(mod_cur[M_A + i] * 7 + (1<<16)) >> 17) + 4, 0, 7);
-		if (scopey >= 0 && scopey < 8)
-			lfo_history[lfohp][i] |= 1 << scopey;
-		
-
+		bool moving_up = scopey > old_scopey;
+		// a new scope frame always needs to write at least one pixel
+		if (new_scope_frame && old_scopey == scopey)
+			lfo_history[lfo_scope_frame][i] |= 1 << scopey;
+		// draw line towards the new position
+		while (old_scopey != scopey) {
+			old_scopey += moving_up ? 1 : -1;
+			lfo_history[lfo_scope_frame][i] |= 1 << old_scopey;
+		}
+		// save position
+		prev_scopey[i] = scopey;
 	}
 
 

--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -1915,6 +1915,7 @@ void DoAudio(u32 *dst, u32 *audioin) {
 	if (!whichhalf) {
 		total_ui_pressure = 0;
 		read_from_seq = false;
+		prev_physical_touch_finger = physical_touch_finger;
 	}
 	// update strings
 	for (int fi = whichhalf; fi < whichhalf + 4; ++fi) {
@@ -1923,7 +1924,7 @@ void DoAudio(u32 *dst, u32 *audioin) {
 	// end of a full update of all strings
 	if (whichhalf) {
 		// you've released your fingers, you're recording in step mode - let's advance!
-		if (total_ui_pressure<=0 && prev_total_ui_pressure <= 0 && prev_prev_total_ui_pressure > 0 && recording && !isplaying()) {
+		if (!physical_touch_finger && prev_physical_touch_finger && recording && !isplaying()) {
 			set_cur_step(cur_step + 1, false);
 		}
 		prev_prev_total_ui_pressure = prev_total_ui_pressure;

--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -407,12 +407,12 @@ void update_params(int fingertrig, int fingerdown) {
 	pressure16 = maxp * (65536 / 2048);
 	// update lfos on modulation sources
 
-	float aknob = clampf(GetADCSmoothed(ADC_AKNOB), -1.f, 1.f);
-	float bknob = clampf(GetADCSmoothed(ADC_BKNOB), -1.f, 1.f);
-	float acv = clampf(GetADCSmoothed(ADC_ACV) * IN_CV_SCALE, -1.f, 1.f);
-	float bcv = clampf(GetADCSmoothed(ADC_BCV) * IN_CV_SCALE, -1.f, 1.f);
-	float xcv = clampf(GetADCSmoothed(ADC_XCV) * IN_CV_SCALE, -1.f, 1.f);
-	float ycv = clampf(GetADCSmoothed(ADC_YCV) * IN_CV_SCALE, -1.f, 1.f);
+	float aknob = clampf(GetADCCalibrated(ADC_AKNOB), -1.f, 1.f);
+	float bknob = clampf(GetADCCalibrated(ADC_BKNOB), -1.f, 1.f);
+	float acv = clampf(GetADCCalibrated(ADC_ACV) * IN_CV_SCALE, -1.f, 1.f);
+	float bcv = clampf(GetADCCalibrated(ADC_BCV) * IN_CV_SCALE, -1.f, 1.f);
+	float xcv = clampf(GetADCCalibrated(ADC_XCV) * IN_CV_SCALE, -1.f, 1.f);
+	float ycv = clampf(GetADCCalibrated(ADC_YCV) * IN_CV_SCALE, -1.f, 1.f);
 
 	//	accelerometer
 	static int accel_counter;
@@ -438,8 +438,8 @@ void update_params(int fingertrig, int fingerdown) {
 
 	int gatesense = getgatesense();
 	int pitchsense = getpitchsense();
-	float pitchcv = pitchsense ? GetADCSmoothed(ADC_PITCH) : 0.f;
-	float gatecv = gatesense ? clampf(GetADCSmoothed(ADC_GATE)*1.15f-0.05f, 0.f, 1.f) : 1.f;
+	float pitchcv = pitchsense ? GetADCCalibrated(ADC_PITCH) : 0.f;
+	float gatecv = gatesense ? clampf(GetADCCalibrated(ADC_GATE)*1.15f-0.05f, 0.f, 1.f) : 1.f;
 	knobsmooth_update_cv(adc_smooth + 0, acv);
 	knobsmooth_update_cv(adc_smooth + 1, bcv);
 	knobsmooth_update_cv(adc_smooth + 2, xcv);
@@ -1669,7 +1669,7 @@ void processmidimsg(u8 msg, u8 d1, u8 d2) {
 
 void DoRecordModeAudio(u32* dst, u32* audioin) {
 	// recording or level testing
-	int newaudiorec_gain = 65535 - GetADCSmoothedNoCalib(ADC_AKNOB);
+	int newaudiorec_gain = 65535 - GetADCNoCalib(ADC_AKNOB);
 	if (abs(newaudiorec_gain - audiorec_gain_target) > 256) // hysteresis
 		audiorec_gain_target = newaudiorec_gain;
 	knobsmooth_update_knob(&recgain_smooth, audiorec_gain_target, 65536.f);
@@ -3288,11 +3288,11 @@ void EMSCRIPTEN_KEEPALIVE plinky_init(void) {
 		flash_writecalib(3);
 	}
 	HAL_Delay(80);
-	int knoba= GetADCSmoothedNoCalib(ADC_AKNOB);
-	int knobb= GetADCSmoothedNoCalib(ADC_BKNOB);
+	int knoba= GetADCNoCalib(ADC_AKNOB);
+	int knobb= GetADCNoCalib(ADC_BKNOB);
 	bootswish();
-	knoba=abs(knoba-(int)GetADCSmoothedNoCalib(ADC_AKNOB));
-	knobb=abs(knobb-(int)GetADCSmoothedNoCalib(ADC_BKNOB));
+	knoba=abs(knoba-(int)GetADCNoCalib(ADC_AKNOB));
+	knobb=abs(knobb-(int)GetADCNoCalib(ADC_BKNOB));
 	DebugLog("knob turned by %d,%d during boot\r\n", knoba,knobb);
 	//knoba = 10000; // DO NOT CHECK IN - FORCE CALIBRATION
 	//knobb = 10000; // DO NOT CHECK IN - FORCE CV CALIB

--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -517,7 +517,7 @@ void update_params(int fingertrig, int fingerdown) {
 		expander_out[i] = clampi(EXPANDER_ZERO - (int)(expander_val), 0, EXPANDER_MAX);
 
 
-		int scopey = (-(mod_cur[M_A + i] * 7 + (1<<16)) >> 17) + 4;
+		u8 scopey = clampi((-(mod_cur[M_A + i] * 7 + (1<<16)) >> 17) + 4, 0, 7);
 		if (scopey >= 0 && scopey < 8)
 			lfo_history[lfohp][i] |= 1 << scopey;
 		

--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -914,7 +914,7 @@ void finger_synth_update(int fi) {
 	// === CV GATE === //
 
 	// scale pressure with cv gate input
-	pressure = (int)((pressure + 256) * adc_smooth[7].y2) - 256;
+	pressure = pressure * adc_smooth[7].y2;
 
 	// save input results to global variables to be used by other code
 	synth_finger->pressure = pressure;

--- a/sw/Core/Src/ui.h
+++ b/sw/Core/Src/ui.h
@@ -504,20 +504,19 @@ static int frame = 0;
 void DrawLFOs(void) {
 	u8* vr = getvram();
 	vr += 128 - 16;
-	u8 lfohp = ((lfo_history_pos >> 4) + 1) & 15;
+	u8 draw_frame = (lfo_scope_frame + 1) & 15;
 	for (int x = 0; x < 16; ++x) {
-		vr[0] &= ~(lfo_history[lfohp][0] >> 1);
-		vr[128] &= ~(lfo_history[lfohp][1] >> 1);
-		vr[256] &= ~(lfo_history[lfohp][2] >> 1);
-		vr[384] &= ~(lfo_history[lfohp][3] >> 1);
+		vr[0] &= ~(lfo_history[draw_frame][0] >> 1);
+		vr[128] &= ~(lfo_history[draw_frame][1] >> 1);
+		vr[256] &= ~(lfo_history[draw_frame][2] >> 1);
+		vr[384] &= ~(lfo_history[draw_frame][3] >> 1);
 
-
-		vr[0] |= lfo_history[lfohp][0];
-		vr[128] |= lfo_history[lfohp][1];
-		vr[256] |= lfo_history[lfohp][2];
-		vr[384] |= lfo_history[lfohp][3];
+		vr[0] |= lfo_history[draw_frame][0];
+		vr[128] |= lfo_history[draw_frame][1];
+		vr[256] |= lfo_history[draw_frame][2];
+		vr[384] |= lfo_history[draw_frame][3];
 		vr++;
-		lfohp = (lfohp + 1) & 15;
+		draw_frame = (draw_frame + 1) & 15;
 	}
 }
 


### PR DESCRIPTION
**fix #34** 
When checking whether the sequencer should automatically step forward because it is in step-recording mode, it now only checks for physical touches. It used to check for any kind of pressure, including the pressure of itself previewing the sequenced note(s) in that step and midi notes

**fix #44**
This allows latch recall while a shift button is being pressed - effectively no longer muting the latched notes during shift presses. It's basically just a reordering of the existing code

**fix #48** 
When externally sequencing midi notes on the same step to play a chord, they can come in on the same frame in the Plinky. This means they are not making any sound yet _and_ plinky hasn't had the chance yet to set the `synthfingerdown_nogatelen_internal` variable in `doAudio()`. This means a check for the midi-specific variable `midi_pressure_override` had to be added to truly check whether a string is already occupied by a midi note

While it is unlikely that a midi note comes in exactly at the frame where a pad is also physically pressed but is not making sound yet, I have still added a check for `synthfingerdown_nogatelen_internal` in the "non-pressed, non-sounding strings" check, just in case. This means a midi note + finger press on the same frame get handled properly as well

**fix octave range**
The existing octave range allowed for many pads (over two columns on either extreme, with default column setting) to be unusable as they fall outside of the available pitch range. The range is brought back from 4 to 3 octaves - which still allows for reaching the full range of pitches on either extreme but allows for fewer unusable pads

When playing way beyond the absolute bottom pitch (~F-3) the lower columns start bugging out to the point where they don't produce sound anymore, even if the octave setting is brought back up. The lower limit with octaves -3 is C-2. The pitch can still be brought down up to an octave with the pitch parameter, but I feel this is sufficient protection against reaching that buggy pitch range

At the upper extreme, higher pads just keep playing D#7 without bugging out, which is fine

**simplify gate cv multiplier**
In my quest to trace the ADC pipeline and how the range of the gate cv was exactly calculated, I renamed two methods - mostly for my own understanding

As for the cv gate multiplier, it used to be:
```cpp
pressure = (int)((pressure + 256) * adc_smooth[7].y2) - 256;
```
This seems to scale around a neutral point at value 256, but I don't think that neutral point is there. As `adc_smooth[7].y2` is just a float between 0 and 1, it makes most sense to me to make this a simple multiplication:
```cpp
pressure = pressure * adc_smooth[7].y2;
```

**euro clock improvements**
- When the clock automatically reverts from external to internal, the sequencer is stopped. (Goes for both euro and midi clock.) Having a sequence suddenly change tempo while playing is undesired in most situations
- When the clock moves from internal to external, and that change is triggered by a eurorack clock, the sequencer resets and starts playing. This plus the automatic stopping of the sequence when external clock stops makes playing the plinky sequencer in a eurorack context a lot more intuitive

**lfo scope improvements**
Lfo shapes that include vertical lines (square, saw, castle, etc) now display those vertical lines. The scope values are now also clamped to [0..7] instead of disappearing when the scaling math places the scope value outside of that range