### PR TITLE
V0.B2 bug fixes

### DIFF
--- a/sw/Core/Src/plinky.c
+++ b/sw/Core/Src/plinky.c
@@ -2043,7 +2043,8 @@ void DoAudio(u32 *dst, u32 *audioin) {
 				Finger* f = fingers_synth_sorted[fi] + 2;
 				int midinote = ((midi_notes[fi]-12*2) << 9) + midi_chan_pitchbend[midi_channels[fi]]/8;
 				for (int i = 0; i < 4; ++i) {
-					int pitch = pitchbase + ((i & 1) ? interval : 0) + (i-2)*64 + midinote; //  (lookupscale(scale, ystep + root)) + +((fine * microtune) >> 14);
+					int fine_pitch = ((i-2)*64 * param_eval_finger(P_MICROTUNE, fi, synthf)) >> 16;
+					int pitch = pitchbase + ((i & 1) ? interval : 0) + fine_pitch + midinote; //  (lookupscale(scale, ystep + root)) + +((fine * microtune) >> 14);
 					totpitch += pitch;
 					voices[fi].theosc[i].pitch = pitch;
 					voices[fi].theosc[i].targetdphase = maxi(65536, (int)(table_interp(pitches, pitch + PITCH_BASE) * (65536.f * 128.f)));

--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -728,7 +728,7 @@ void finger_synth_update(int fi) {
 
 	// === TOUCH INPUT === //
 
-	if (!is_finger_an_edit_operation(fi)) {
+	if (!is_finger_an_edit_operation(fi) || editmode == EM_SAMPLE) {
 		// read touch values from ui
 		pressure = ui_finger->pressure;
 		position = ui_finger->pos;

--- a/sw/Core/Src/touch.h
+++ b/sw/Core/Src/touch.h
@@ -1,3 +1,5 @@
+#define TOUCH_MIN_PRES -2048
+
 u16 finger_raw[36]; // raw value back from stm
 u16 finger_min[36]; // lowest value seen (zero point)
 u16 finger_max[36]; // highest value seen (zero point)
@@ -719,7 +721,7 @@ void finger_synth_update(int fi) {
 	int previous_pressure = fingers_ui_time[fi][(ui_frame - 2) & 7].pressure;
 	int substep = calcseqsubstep(0, 8);
 	bool latchon = (rampreset.flags & FLAGS_LATCH);
-	int pressure = 0;
+  	int pressure = TOUCH_MIN_PRES;
 	int position = 0;
 	bool pressure_increasing;
 	bool position_updated = false;


### PR DESCRIPTION
### String envelope fix
_plink_rj_0B3_01_

**Issue:**
When holding any of the shift pads while the sequencer is playing, the synth sound would get a lot less bright

**Technical issue:**
Holding a shift-pad stops the synth from reading out the pads, which makes it revert to the initalized value: 0. Reading out the pressure of an untouched pad is closer to -1900

Technically a pressure value of 0 should be enough to register a released finger, but apparently in reality it doesn't, which made it so that the envelope didn't re-enter its attack phase - and went straight from zero to sustain level

**Solution:**
Initialize the pressure to the lowest possible touch pressure

### No audio in sample edit mode fix
_plink_rj_0B3_02_

**Issue:**
When editing slice markers in sample edit mode, there was no audio anymore to preview the slice

**Solution:**
The code that saves physical touches into synth finger touches needed an extra exception in its conditional so that it executes during sample edit mode, even though pad presses in that mode are technically an edit operation and not a synth touch.

### Fix excessive oscillator pitch spread for midi notes
_plink_rj_0B3_03_

**Issue #72**

**Solution:**
The pitch spread for midi notes is now multiplied by the microtone parameter. 100% equals the pitch spread we had until 0.B2 and it scales down linearly to zero. The most important part of this fix is that people at least have control over the depth of the pitch spread. The default value of microtone is 12.5%, so the default patch will sound different for midi. (Which is desirable in my opinion.)

This is a quick fix until we do a more structural overhaul of the midi calculations and mapping