### PR TITLE
Suppress rwx warning

### DIFF
--- a/sw/nocube_makefile/Makefile
+++ b/sw/nocube_makefile/Makefile
@@ -91,7 +91,8 @@ CFLAGS_COMMON = -mcpu=cortex-m4 \
     --specs=nano.specs \
     -mfpu=fpv4-sp-d16 \
     -mfloat-abi=hard \
-    -mthumb
+    -mthumb \
+    -Wno-rwx-segment
 
 LDFLAGS_COMMON = -mcpu=cortex-m4 \
     -T"../STM32L476VGTX_FLASH.ld" \


### PR DESCRIPTION
~~Suppress safety warning that isn't really relevant on embedded systems, makes building a little less noisy~~
Nope