### PR TITLE
Adjusted calib check for Plinky+

### DIFF
--- a/sw/Core/Src/calib.h
+++ b/sw/Core/Src/calib.h
@@ -406,7 +406,7 @@ again:
 							snprintf(helptext, sizeof(helptext), "!pad %d lower not conn\ncheck soldering", si + 1);
 							errors |= (1 << si);
 						}
-						else if (abs(calibresults[si].pos[step] - calibresults[si].pos[7]) < 300) {
+						else if (abs(calibresults[si].pos[step] - calibresults[si].pos[7]) < 250) { // previously 300
 							snprintf(helptext, sizeof(helptext), "!pad %d shorted?\ncheck soldering", si + 1);
 							errors |= (1 << si);
 						}

--- a/sw/Core/Src/config.h
+++ b/sw/Core/Src/config.h
@@ -62,7 +62,8 @@
 // 0.B0 - MORE RJ MAGIC - https://github.com/plinkysynth/plinky_public/pull/40 - what a beast he is.
 // 0.B1 - More RJ - lfo drawing is nicer; adc is not so smoothed?
 // 0.B2 - Pin detection for Plinky+ - boot the alternate display code for SSD1305 display driver
-#define VERSION2			  "v0.B2"
+// 0.B3 - slightly adjusted configuration to work better for Plinky+
+#define VERSION2			  "v0.B3"
 
 // the bootloader is manually copied to the file golden_bootloader.bin
 // makebin.py uses it to make a UF2 file containing the bootloader + latest firmware together


### PR DESCRIPTION
A good calibration would sometimes fail at calibration check, throwing a false short diagnosis.